### PR TITLE
Remove DOM type dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tsconfig.tsbuildinfo
 coverage
 *.tgz
 .nyc_output
+.idea

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,7 +9,7 @@ module.exports = config => {
       'karma-spec-reporter'
     ],
     karmaTypescriptConfig: {
-      tsconfig: './tsconfig.karma.json'
+      tsconfig: './tsconfig.test.json'
     },
     client: {
       // leave Jasmine Spec Runner output visible in browser

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "browser": "lib/index.js",
   "scripts": {
     "build": "tsc",
-    "test": "ts-node node_modules/jasmine/bin/jasmine test/*_spec.ts",
+    "test": "ts-node --project ./tsconfig.test.json node_modules/jasmine/bin/jasmine test/*_spec.ts",
     "test:browsers": "karma start --single-run",
     "test:sax": "tap sax-test/*.js",
     "pretty": "prettier --write '**/*.{ts,js}'",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@journeyapps/domparser",
   "description": "Basic XML DOM parsing",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "main": "lib/node.js",
   "browser": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "description": "Basic XML DOM parsing",
   "version": "0.2.0",
   "license": "MIT",
-  "main": "lib/index.js",
+  "main": "lib/node.js",
+  "browser": "lib/index.js",
   "scripts": {
     "build": "tsc",
     "test": "ts-node node_modules/jasmine/bin/jasmine test/*_spec.ts",
@@ -34,6 +35,8 @@
     "xmldom": "^0.1.27"
   },
   "files": [
-    "lib"
+    "lib",
+    "types.d.ts",
+    "types.js"
   ]
 }

--- a/src/DOMImplementation.ts
+++ b/src/DOMImplementation.ts
@@ -1,0 +1,18 @@
+import { XMLDocument } from './XMLDocument';
+import { XMLNodeLike } from './XMLNode';
+
+export interface DOMImplementation {
+  createDocument(
+    namespaceURI: string | null,
+    qualifiedName: string | null,
+    type?: any
+  ): XMLDocument;
+}
+
+export interface XMLDOMParser {
+  parseFromString(source: string, type?: string, options?: any): XMLDocument;
+}
+
+export interface XMLSerializer {
+  serializeToString(anyNode: XMLNodeLike): string;
+}

--- a/src/DOMParser.ts
+++ b/src/DOMParser.ts
@@ -7,6 +7,7 @@ import { XMLDocument } from './XMLDocument';
 import { XMLLocator } from './XMLLocator';
 import { XMLAttributePosition } from './XMLAttributePosition';
 import { XMLNode } from './XMLNode';
+import { DOMImplementation } from './DOMImplementation';
 
 function getMatch(re: RegExp, pos: number, str: string) {
   var match = re.exec(str);
@@ -25,14 +26,6 @@ function errorFromMessage(message: string) {
   var line = parseInt(getMatch(/Line: (\d+)/, 1, message), 10);
   var column = parseInt(getMatch(/Column: (\d+)/, 1, message), 10);
   return new XMLError(msg, { line: line, column: column });
-}
-
-export interface DOMImplementation {
-  createDocument(
-    namespaceURI: string | null,
-    qualifiedName: string | null,
-    type?: any
-  ): XMLDocument;
 }
 
 export interface DOMParserOptions {

--- a/src/DOMParser.ts
+++ b/src/DOMParser.ts
@@ -27,30 +27,37 @@ function errorFromMessage(message: string) {
   return new XMLError(msg, { line: line, column: column });
 }
 
+export interface DOMImplementation {
+  createDocument(
+    namespaceURI: string | null,
+    qualifiedName: string | null,
+    type?: any
+  ): XMLDocument;
+}
+
 export interface DOMParserOptions {
   implementation: DOMImplementation;
 }
 
-export class DOMParser implements globalThis.DOMParser {
-  private options: DOMParserOptions;
+export class DOMParser {
+  private options?: DOMParserOptions;
 
   constructor(options?: Partial<DOMParserOptions>) {
     this.options = (options || {}) as DOMParserOptions;
     if (!this.options.implementation) {
-      this.options.implementation = native.implementation;
+      this.options.implementation = (native.implementation as unknown) as DOMImplementation;
     }
   }
 
-  parseFromString(source: string, _type?: SupportedType): XMLDocument {
+  parseFromString(
+    source: string,
+    _type?: 'text/html' | 'text/xml' | 'application/xml'
+  ): XMLDocument {
     const locator = new XMLLocator(source);
 
     const parser = sax.parser(true, { xmlns: true, attributePosition: true });
     let errors: XMLError[] = [];
-    let doc = this.options.implementation.createDocument(
-      null,
-      null,
-      null
-    ) as XMLDocument;
+    let doc = this.options.implementation.createDocument(null, null, null);
     doc.locator = locator;
     let current: XMLNode = doc;
 

--- a/src/IterableNodeList.ts
+++ b/src/IterableNodeList.ts
@@ -1,5 +1,9 @@
 import { XMLNode } from './XMLNode';
 
-export interface IterableNodeList<T extends XMLNode = XMLNode>
-  extends NodeListOf<T>,
-    Iterable<T> {}
+export interface IterableNodeList<T extends XMLNode = XMLNode> {
+  readonly length: number;
+  item(index: number): T;
+  [index: number]: T;
+
+  forEach?: any;
+}

--- a/src/XMLAttribute.ts
+++ b/src/XMLAttribute.ts
@@ -1,5 +1,12 @@
 import { XMLElement } from './XMLElement';
+import { XMLNode } from './XMLNode';
 
-export interface XMLAttribute extends Attr {
+export interface XMLAttribute extends XMLNode {
   readonly ownerElement: XMLElement | null;
+  readonly localName: string;
+  readonly name: string;
+  readonly namespaceURI: string | null;
+  readonly prefix: string | null;
+  readonly specified: boolean;
+  value: string;
 }

--- a/src/XMLDocument.ts
+++ b/src/XMLDocument.ts
@@ -70,7 +70,7 @@ export interface XMLDocument extends XMLNode {
   createProcessingInstruction(
     target: string,
     data: string
-  ): XMLNode & ProcessingInstruction;
+  ): XMLNode;
   /**
    * Creates an instance of the element for the specified tag.
    * @param tagName The name of an element.
@@ -80,11 +80,11 @@ export interface XMLDocument extends XMLNode {
   createElementNS(
     namespaceURI: string | null,
     qualifiedName: string,
-    options?: ElementCreationOptions
+    options?: any
   ): XMLElement;
   createElementNS(
     namespace: string | null,
     qualifiedName: string,
-    options?: ElementCreationOptions
+    options?: any
   ): XMLElement;
 }

--- a/src/XMLDocument.ts
+++ b/src/XMLDocument.ts
@@ -67,10 +67,7 @@ export interface XMLDocument extends XMLNode {
    * If data contains "?>" an
    * "InvalidCharacterError" DOMException will be thrown.
    */
-  createProcessingInstruction(
-    target: string,
-    data: string
-  ): XMLNode;
+  createProcessingInstruction(target: string, data: string): XMLNode;
   /**
    * Creates an instance of the element for the specified tag.
    * @param tagName The name of an element.

--- a/src/XMLDocument.ts
+++ b/src/XMLDocument.ts
@@ -1,44 +1,40 @@
 import { XMLError } from './XMLError';
 import { XMLElement } from './XMLElement';
 import { XMLLocator } from './XMLLocator';
-import { XMLNode } from './XMLNode';
+import { XMLNode, XMLCharacterNode } from './XMLNode';
+import { IterableNodeList } from './IterableNodeList';
 
 /**
  * A Document extended with:
  * 1. Parse errors.
  * 2. Positional info.
  */
-export type XMLDocument = XMLNode & XMLDocumentInternal;
+export interface XMLDocument extends XMLNode {
+  documentElement: XMLElement;
 
-// We cannot extend both XMLNode and Document, so we use intersection types
-interface XMLDocumentInternal extends Document {
-  documentElement: XMLElement & HTMLElement;
+  errors?: XMLError[];
+  xmlVersion?: string;
+  locator?: XMLLocator;
 
-  errors: XMLError[];
-  xmlVersion: string;
-  locator: XMLLocator;
+  readonly parentNode: XMLNode | null;
 
-  readonly parentNode: XMLNode & ParentNode | null;
-
-  getElementsByTagName(qualifiedName: string): HTMLCollectionOf<XMLElement>;
-
-  // Our versions of createElement and others
+  getElementsByTagName(qualifiedName: string): IterableNodeList<XMLElement>;
 
   /**
    * Returns a CDATASection node whose data is data.
    */
-  createCDATASection(data: string): XMLNode & CDATASection;
+  createCDATASection(data: string): XMLCharacterNode;
   /**
    * Creates a comment object with the specified data.
    * @param data Sets the comment object's data.
    */
-  createComment(data: string): XMLNode & Comment;
+  createComment(data: string): XMLCharacterNode;
 
   /**
    * Creates a text string from the specified value.
    * @param data String that specifies the nodeValue property of the text node.
    */
-  createTextNode(data: string): XMLNode & Text;
+  createTextNode(data: string): XMLCharacterNode;
 
   /**
    * Returns a ProcessingInstruction node whose target is target and data is data.
@@ -67,34 +63,4 @@ interface XMLDocumentInternal extends Document {
     qualifiedName: string,
     options?: ElementCreationOptions
   ): XMLElement;
-
-  // Overloads for interface compatibility.
-
-  /**
-   * Creates an instance of the element for the specified tag.
-   * @param tagName The name of an element.
-   */
-  createElement<K extends keyof HTMLElementTagNameMap>(
-    tagName: K,
-    options?: ElementCreationOptions
-  ): HTMLElementTagNameMap[K];
-  /** @deprecated */
-  createElement<K extends keyof HTMLElementDeprecatedTagNameMap>(
-    tagName: K,
-    options?: ElementCreationOptions
-  ): HTMLElementDeprecatedTagNameMap[K];
-  createElement(tagName: string, options?: ElementCreationOptions): HTMLElement;
-
-  createElementNS(
-    namespaceURI: 'http://www.w3.org/1999/xhtml',
-    qualifiedName: string
-  ): HTMLElement;
-  createElementNS<K extends keyof SVGElementTagNameMap>(
-    namespaceURI: 'http://www.w3.org/2000/svg',
-    qualifiedName: K
-  ): SVGElementTagNameMap[K];
-  createElementNS(
-    namespaceURI: 'http://www.w3.org/2000/svg',
-    qualifiedName: string
-  ): SVGElement;
 }

--- a/src/XMLDocument.ts
+++ b/src/XMLDocument.ts
@@ -3,6 +3,7 @@ import { XMLElement } from './XMLElement';
 import { XMLLocator } from './XMLLocator';
 import { XMLNode, XMLCharacterNode } from './XMLNode';
 import { IterableNodeList } from './IterableNodeList';
+import { DOMImplementation } from './DOMImplementation';
 
 /**
  * A Document extended with:
@@ -12,6 +13,8 @@ import { IterableNodeList } from './IterableNodeList';
 export interface XMLDocument extends XMLNode {
   documentElement: XMLElement;
 
+  implementation: DOMImplementation;
+
   errors?: XMLError[];
   xmlVersion?: string;
   locator?: XMLLocator;
@@ -19,6 +22,24 @@ export interface XMLDocument extends XMLNode {
   readonly parentNode: XMLNode | null;
 
   getElementsByTagName(qualifiedName: string): IterableNodeList<XMLElement>;
+  /**
+   * Returns a reference to the first object with the specified value of the ID or NAME attribute.
+   * @param elementId String that specifies the ID value. Case-insensitive.
+   */
+  getElementById(elementId: string): XMLElement | null;
+
+  /**
+   * Gets a collection of objects based on the value of the NAME or ID attribute.
+   * @param elementName Gets a collection of objects based on the value of the NAME or ID attribute.
+   */
+  getElementsByName(elementName: string): IterableNodeList<XMLElement>;
+  /**
+   * Retrieves a collection of objects based on the specified element name.
+   * @param name Specifies the name of an element.
+   */
+  getElementsByTagName(qualifiedName: string): IterableNodeList<XMLElement>;
+
+  getElementsByTagNameNS(namespaceURI: string, localName: string): IterableNodeList<XMLElement>;
 
   /**
    * Returns a CDATASection node whose data is data.

--- a/src/XMLDocument.ts
+++ b/src/XMLDocument.ts
@@ -39,7 +39,10 @@ export interface XMLDocument extends XMLNode {
    */
   getElementsByTagName(qualifiedName: string): IterableNodeList<XMLElement>;
 
-  getElementsByTagNameNS(namespaceURI: string, localName: string): IterableNodeList<XMLElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string,
+    localName: string
+  ): IterableNodeList<XMLElement>;
 
   /**
    * Returns a CDATASection node whose data is data.

--- a/src/XMLElement.ts
+++ b/src/XMLElement.ts
@@ -4,18 +4,42 @@ import { XMLAttribute } from './XMLAttribute';
 import { XMLNode } from './XMLNode';
 import { IterableNodeList } from './IterableNodeList';
 
-// We cannot extend from both XMLNode and Element (type conflicts), so we & the types instead.
-export type XMLElement = XMLElementInternal & Element;
-
-interface XMLElementInternal extends XMLNode {
+export interface XMLElement extends XMLNode {
   // Specializing the standard properties
   getAttributeNode(name: string): XMLAttribute | null;
   getAttributeNodeNS(
     namespaceURI: string,
     localName: string
   ): XMLAttribute | null;
+  /**
+   * Sets the value of element's first attribute whose qualified name is qualifiedName to value.
+   */
+  setAttribute(qualifiedName: string, value: string): void;
+  /**
+   * Sets the value of element's attribute whose namespace is namespace and local name is localName to value.
+   */
+  setAttributeNS(
+    namespace: string | null,
+    qualifiedName: string,
+    value: string
+  ): void;
+  setAttributeNode(attr: Attr): Attr | null;
+  setAttributeNodeNS(attr: Attr): Attr | null;
+
+  /**
+   * Returns element's first attribute whose qualified name is qualifiedName, and null if there is no such attribute otherwise.
+   */
+  getAttribute(qualifiedName: string): string | null;
+  /**
+   * Returns element's attribute whose namespace is namespace and local name is localName, and null if there is no such attribute otherwise.
+   */
+  getAttributeNS(namespace: string | null, localName: string): string | null;
 
   ownerDocument: XMLDocument;
+
+  readonly localName: string;
+  readonly prefix: string;
+  readonly attributes: NamedNodeMap;
 
   /**
    * Returns the children.
@@ -31,4 +55,16 @@ interface XMLElementInternal extends XMLNode {
   nameStart?: number;
   nameEnd?: number;
   attributePositions?: { [key: string]: XMLAttributePosition };
+}
+
+interface NamedNodeMap<T = XMLAttribute> {
+  readonly length: number;
+  getNamedItem(qualifiedName: string): T | null;
+  getNamedItemNS(namespace: string | null, localName: string): T | null;
+  item(index: number): T | null;
+  removeNamedItem(qualifiedName: string): T;
+  removeNamedItemNS(namespace: string | null, localName: string): T;
+  setNamedItem(attr: T): T | null;
+  setNamedItemNS(attr: T): T | null;
+  [index: number]: T;
 }

--- a/src/XMLElement.ts
+++ b/src/XMLElement.ts
@@ -23,8 +23,8 @@ export interface XMLElement extends XMLNode {
     qualifiedName: string,
     value: string
   ): void;
-  setAttributeNode(attr: Attr): Attr | null;
-  setAttributeNodeNS(attr: Attr): Attr | null;
+  setAttributeNode(attr: XMLAttribute): XMLAttribute | null;
+  setAttributeNodeNS(attr: XMLAttribute): XMLAttribute | null;
 
   /**
    * Returns element's first attribute whose qualified name is qualifiedName, and null if there is no such attribute otherwise.
@@ -55,7 +55,7 @@ export interface XMLElement extends XMLNode {
    * Removes element's attribute whose namespace is namespace and local name is localName.
    */
   removeAttributeNS(namespace: string | null, localName: string): void;
-  removeAttributeNode(attr: XMLAttribute): Attr;
+  removeAttributeNode(attr: XMLAttribute): XMLAttribute;
 
   ownerDocument: XMLDocument;
 

--- a/src/XMLElement.ts
+++ b/src/XMLElement.ts
@@ -35,8 +35,31 @@ export interface XMLElement extends XMLNode {
    */
   getAttributeNS(namespace: string | null, localName: string): string | null;
 
+  /**
+   * Returns true if element has an attribute whose qualified name is qualifiedName, and false otherwise.
+   */
+  hasAttribute(qualifiedName: string): boolean;
+  /**
+   * Returns true if element has an attribute whose namespace is namespace and local name is localName.
+   */
+  hasAttributeNS(namespace: string | null, localName: string): boolean;
+  /**
+   * Returns true if element has attributes, and false otherwise.
+   */
+  hasAttributes(): boolean;
+  /**
+   * Removes element's first attribute whose qualified name is qualifiedName.
+   */
+  removeAttribute(qualifiedName: string): void;
+  /**
+   * Removes element's attribute whose namespace is namespace and local name is localName.
+   */
+  removeAttributeNS(namespace: string | null, localName: string): void;
+  removeAttributeNode(attr: XMLAttribute): Attr;
+
   ownerDocument: XMLDocument;
 
+  readonly tagName: string;
   readonly localName: string;
   readonly prefix: string;
   readonly attributes: NamedNodeMap;

--- a/src/XMLNode.ts
+++ b/src/XMLNode.ts
@@ -2,6 +2,19 @@ import { XMLElement } from './XMLElement';
 import { XMLDocument } from './XMLDocument';
 import { IterableNodeList } from './IterableNodeList';
 
+export const ELEMENT_NODE = 1;
+export const ATTRIBUTE_NODE = 2;
+export const TEXT_NODE = 3;
+export const CDATA_SECTION_NODE = 4;
+export const ENTITY_REFERENCE_NODE = 5;
+export const ENTITY_NODE = 6;
+export const PROCESSING_INSTRUCTION_NODE = 7;
+export const COMMENT_NODE = 8;
+export const DOCUMENT_NODE = 9;
+export const DOCUMENT_TYPE_NODE = 10;
+export const DOCUMENT_FRAGMENT_NODE = 11;
+export const NOTATION_NODE = 12;
+
 export interface XMLNodeLike {
   readonly nodeType: number;
 
@@ -54,7 +67,7 @@ export interface XMLNode extends XMLNodeLike {
 
   readonly namespaceURI: string;
 
-  readonly textContent: string;
+  textContent: string;
 
   /**
    * Returns a copy of node. If deep is true, the copy also includes the node's descendants.
@@ -65,7 +78,8 @@ export interface XMLNode extends XMLNodeLike {
 
   hasChildNodes(): boolean;
 
-  appendChild<Q extends any>(newChild: Q): Q;
+  appendChild<T extends XMLNode>(newChild: T): T;
+  insertBefore<T extends XMLNode>(newChild: T, refChild: XMLNode | null): T;
 }
 
 export interface XMLCharacterNode extends XMLNode {

--- a/src/XMLNode.ts
+++ b/src/XMLNode.ts
@@ -2,26 +2,34 @@ import { XMLElement } from './XMLElement';
 import { XMLDocument } from './XMLDocument';
 import { IterableNodeList } from './IterableNodeList';
 
-export interface XMLNode extends Node {
+export interface XMLNodeLike {
+  readonly nodeType: number;
+
+  readonly nodeName: string;
+
+  nodeValue: string | null;
+}
+
+export interface XMLNode extends XMLNodeLike {
   /**
    * Returns the children.
    */
-  readonly childNodes: IterableNodeList<XMLNode & ChildNode>;
+  readonly childNodes: IterableNodeList<XMLNode>;
 
   /**
    * Returns the first child.
    */
-  readonly firstChild: XMLNode & ChildNode | null;
+  readonly firstChild: XMLNode | null;
 
   /**
    * Returns the last child.
    */
-  readonly lastChild: XMLNode & ChildNode | null;
+  readonly lastChild: XMLNode | null;
 
   /**
    * Returns the next sibling.
    */
-  readonly nextSibling: XMLNode & ChildNode | null;
+  readonly nextSibling: XMLNode | null;
 
   /**
    * Returns the node document.
@@ -32,20 +40,35 @@ export interface XMLNode extends Node {
   /**
    * Returns the parent element.
    */
-  readonly parentElement: XMLElement & HTMLElement | null;
+  readonly parentElement: XMLElement | null;
 
   /**
    * Returns the parent.
    */
-  readonly parentNode: XMLNode & ParentNode | null;
+  readonly parentNode: XMLNode | null;
 
   /**
    * Returns the previous sibling.
    */
   readonly previousSibling: XMLNode | null;
 
+  readonly namespaceURI: string;
+
+  readonly textContent: string;
+
   /**
    * Returns a copy of node. If deep is true, the copy also includes the node's descendants.
    */
   cloneNode(deep?: boolean): XMLNode;
+
+  isEqualNode(other: XMLNode | any): boolean;
+
+  hasChildNodes(): boolean;
+
+  appendChild<Q extends any>(newChild: Q): Q;
+}
+
+export interface XMLCharacterNode extends XMLNode {
+  data: string;
+  readonly length: number;
 }

--- a/src/XMLSerializer.ts
+++ b/src/XMLSerializer.ts
@@ -1,24 +1,27 @@
 import * as native from './xmldom';
+import { XMLNode, XMLNodeLike } from './XMLNode';
+import { DOCUMENT_NODE, PROCESSING_INSTRUCTION_NODE, TEXT_NODE } from '.';
 
 function nativeSerializeToString(node) {
   return new native.XMLSerializer().serializeToString(node);
 }
 
 export class XMLSerializer {
-  serializeToString(node: Node) {
+  serializeToString(anyNode: XMLNodeLike) {
+    const node = anyNode as XMLNode;
     // Whitespace characters between processing instructions are lost, and browsers serialize them differently.
     // We write these individually, and include newline characters in between them.
     // Note that our DOMParser is the only one that saves the processing instructions in the DOM, browsers don't do this.
     if (
-      node.nodeType == node.DOCUMENT_NODE &&
+      node.nodeType == DOCUMENT_NODE &&
       node.firstChild &&
-      node.firstChild.nodeType == node.PROCESSING_INSTRUCTION_NODE
+      node.firstChild.nodeType == PROCESSING_INSTRUCTION_NODE
     ) {
       var children = node.childNodes;
       var result = '';
       for (var i = 0; i < children.length; i++) {
         const child = children[i];
-        if (child.nodeType == child.TEXT_NODE) {
+        if (child.nodeType == TEXT_NODE) {
           // Workaround for xmldom inserting extra newlines
           continue;
         }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,0 +1,1 @@
+export * from './index';

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,3 +10,6 @@ export { XMLNode } from './XMLNode';
 export const ELEMENT_NODE = 1;
 export const ATTRIBUTE_NODE = 2;
 export const TEXT_NODE = 3;
+export const PROCESSING_INSTRUCTION_NODE = 7;
+export const COMMENT_NODE = 8;
+export const DOCUMENT_NODE = 9;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,4 @@
 export { DOMParser } from './DOMParser';
 export { XMLSerializer } from './XMLSerializer';
-export { XMLElement } from './XMLElement';
-export { XMLError } from './XMLError';
-export { XMLDocument } from './XMLDocument';
-export { XMLPosition } from './XMLPosition';
-export { XMLAttribute } from './XMLAttribute';
-export { XMLNode } from './XMLNode';
 
-export const ELEMENT_NODE = 1;
-export const ATTRIBUTE_NODE = 2;
-export const TEXT_NODE = 3;
-export const PROCESSING_INSTRUCTION_NODE = 7;
-export const COMMENT_NODE = 8;
-export const DOCUMENT_NODE = 9;
+export * from './types';

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,0 +1,8 @@
+import { setImplementation, setParsers } from './xmldom';
+
+export * from './index';
+
+const xmldom = require('xmldom');
+
+setImplementation(new xmldom.DOMImplementation());
+setParsers(xmldom);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,9 @@
+export { XMLElement } from './XMLElement';
+export { XMLError } from './XMLError';
+export { XMLDocument } from './XMLDocument';
+export { XMLPosition } from './XMLPosition';
+export { XMLAttribute } from './XMLAttribute';
+export { IterableNodeList } from './IterableNodeList';
+
+export * from './XMLNode';
+export * from './DOMImplementation';

--- a/src/xmldom.ts
+++ b/src/xmldom.ts
@@ -1,10 +1,15 @@
-let ourDOMParser: typeof DOMParser;
-let ourXMLSerializer: typeof XMLSerializer;
+import { XMLNode } from './XMLNode';
+import { XMLElement } from './XMLElement';
+import { DOMImplementation, DOMParser as DOMParserInterface } from './DOMParser';
+import { XMLSerializer as XMLSerializerInterface } from './XMLSerializer';
+
+let ourDOMParser: typeof DOMParserInterface;
+let ourXMLSerializer: typeof XMLSerializerInterface;
 let implementation: DOMImplementation;
 
-if (typeof window != 'undefined') {
-  implementation = document.implementation;
-  ourDOMParser = DOMParser;
+if (typeof document != 'undefined') {
+  implementation = document.implementation as DOMImplementation;
+  ourDOMParser = DOMParser as typeof DOMParserInterface;
   ourXMLSerializer = XMLSerializer;
 } else {
   // @ts-ignore
@@ -31,7 +36,7 @@ function same(attr1?: string, attr2?: string) {
   return attr1 == attr2;
 }
 
-function isElement(e: Node): e is Element {
+function isElement(e: XMLNode): e is XMLElement {
   return e.nodeType == 1;
 }
 
@@ -40,7 +45,7 @@ function isElement(e: Node): e is Element {
  *
  * xmldom only implements DOM level 2, which doesn't contain this function.
  */
-export function isEqualNode(a: Node, b: Node): boolean {
+export function isEqualNode(a: XMLNode, b: XMLNode): boolean {
   if (typeof a.isEqualNode == 'function') {
     // Use the native version when available
     return a.isEqualNode(b);

--- a/src/xmldom.ts
+++ b/src/xmldom.ts
@@ -1,8 +1,6 @@
 import { XMLNode } from './XMLNode';
 import { XMLElement } from './XMLElement';
-import {
-  DOMParser as DOMParserInterface
-} from './DOMParser';
+import { DOMParser as DOMParserInterface } from './DOMParser';
 import { XMLSerializer as XMLSerializerInterface } from './XMLSerializer';
 import { DOMImplementation } from './DOMImplementation';
 

--- a/src/xmldom.ts
+++ b/src/xmldom.ts
@@ -1,7 +1,10 @@
 import { XMLNode } from './XMLNode';
 import { XMLElement } from './XMLElement';
-import { DOMImplementation, DOMParser as DOMParserInterface } from './DOMParser';
+import {
+  DOMParser as DOMParserInterface
+} from './DOMParser';
 import { XMLSerializer as XMLSerializerInterface } from './XMLSerializer';
+import { DOMImplementation } from './DOMImplementation';
 
 let ourDOMParser: typeof DOMParserInterface;
 let ourXMLSerializer: typeof XMLSerializerInterface;
@@ -11,13 +14,6 @@ if (typeof document != 'undefined') {
   implementation = document.implementation as DOMImplementation;
   ourDOMParser = DOMParser as typeof DOMParserInterface;
   ourXMLSerializer = XMLSerializer;
-} else {
-  // @ts-ignore
-  const xmldom = require('xmldom');
-  implementation = new xmldom.DOMImplementation();
-
-  ourDOMParser = xmldom.DOMParser;
-  ourXMLSerializer = xmldom.XMLSerializer;
 }
 
 export {
@@ -25,6 +21,18 @@ export {
   ourDOMParser as DOMParser,
   ourXMLSerializer as XMLSerializer
 };
+
+export function setImplementation(impl: DOMImplementation) {
+  implementation = impl;
+}
+
+export function setParsers(options: {
+  DOMParser: typeof DOMParserInterface;
+  XMLSerializer: typeof XMLSerializerInterface;
+}) {
+  ourDOMParser = options.DOMParser;
+  ourXMLSerializer = options.XMLSerializer;
+}
 
 function same(attr1?: string, attr2?: string) {
   if (attr1 == null) {

--- a/test/domparser_spec.ts
+++ b/test/domparser_spec.ts
@@ -2,6 +2,10 @@ import { XMLError, DOMParser, XMLSerializer, XMLDocument } from '../src';
 
 import './matchers';
 
+if (typeof window == 'undefined') {
+  require('../src/node');
+}
+
 import * as native from '../src/xmldom';
 
 describe('DOMParser', function() {

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig",
+  "compilerOptions": {
+    "lib": ["es2015", "dom"]
+  },
   "include": [
     "src/*.ts",
     "test/*.ts"

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,4 @@
+// Import this file to only get the types and constants.
+// This helps to make sure that the library is not accidentally added as a runtime dependency.
+
+export * from './lib/types.d';

--- a/types.js
+++ b/types.js
@@ -1,0 +1,2 @@
+// Need this to export constants
+module.exports = require('./lib/types');


### PR DESCRIPTION
Removes all external references to browser `dom` types, making this easier to use from a Node environment.

An additional export `@journeyapps/domparser/types` is added, that only exports types and constants. This is useful to get access to the types, while ensuring that the implementation is not accidentally included in webpack bundles.

A separate import is now added for node, which automatically includes `xmldom` as the DOM implementation. In webpack builds, `xmldom` won't be referenced at all.

