### PR TITLE
[fix] XML string starting with empty newline will create an error.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@journeyapps/domparser",
   "description": "Basic XML DOM parsing",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "MIT",
   "main": "lib/node.js",
   "browser": "lib/index.js",

--- a/src/DOMParser.ts
+++ b/src/DOMParser.ts
@@ -163,6 +163,11 @@ export class DOMParser {
       current.appendChild(doc.createComment(comment));
     };
 
+    //XML needs to start with <...(root element) or <?...(prolog) but not a comment <!-...
+    if(source != null && (source.startsWith("<") !== true || source.startsWith("<!-") === true)){
+      errors.push(new XMLError("XML must start with prolong or root element.", {start: 0, end: 1}, locator))
+    }
+
     try {
       parser.write(source).close();
     } catch (err) {

--- a/src/DOMParser.ts
+++ b/src/DOMParser.ts
@@ -164,8 +164,17 @@ export class DOMParser {
     };
 
     //XML needs to start with <...(root element) or <?...(prolog) but not a comment <!-...
-    if(source != null && (source.startsWith("<") !== true || source.startsWith("<!-") === true)){
-      errors.push(new XMLError("XML must start with prolong or root element.", {start: 0, end: 1}, locator))
+    if (
+      source != null &&
+      (source.startsWith('<') !== true || source.startsWith('<!-') === true)
+    ) {
+      errors.push(
+        new XMLError(
+          'XML must start with prolong or root element.',
+          { start: 0, end: 1 },
+          locator
+        )
+      );
     }
 
     try {

--- a/src/DOMParser.ts
+++ b/src/DOMParser.ts
@@ -166,11 +166,11 @@ export class DOMParser {
     //XML needs to start with <...(root element) or <?...(prolog) but not a comment <!-...
     if (
       source != null &&
-      (source.startsWith('<') !== true || source.startsWith('<!-') === true)
+      (!source.startsWith('<') || source.startsWith('<!--'))
     ) {
       errors.push(
         new XMLError(
-          'XML must start with prolong or root element.',
+          'XML must start with prolog or root element.',
           { start: 0, end: 1 },
           locator
         )

--- a/test/domparser_spec.ts
+++ b/test/domparser_spec.ts
@@ -214,7 +214,7 @@ describe('DOMParser', function () {
       ]);
     });
 
-    it('should not allow views to start with an empty line', function () {
+    it('should report xml strings not starting with prolog or root element', function () {
       let source: string = '\n<view title="Test"></view>';
       let errors = errorsFor(source);
       expect(errors).toEqual([

--- a/test/domparser_spec.ts
+++ b/test/domparser_spec.ts
@@ -213,6 +213,17 @@ describe('DOMParser', function () {
         errorMatching(`Attribute 'attr' redefined.`, { start: 21, end: 25 })
       ]);
     });
+
+    it('should not allow views to start with an empty line', function () {
+      let source: string = '\n<view title="Test"></view>';
+      let errors = errorsFor(source);
+      expect(errors).toEqual([
+        errorMatching('XML must start with prolog or root element.', {
+          start: 0,
+          end: 1
+        })
+      ]);
+    });
   });
 });
 


### PR DESCRIPTION
Added a check that creates an error if the xml string provided for parsing does not start with a tag/element or prolog ('<').